### PR TITLE
Feature: Codecs import

### DIFF
--- a/lib/codec_utils.dart
+++ b/lib/codec_utils.dart
@@ -1,7 +1,43 @@
 library codec_utils;
 
+/// The [Base58Codec] class is designed for encoding data using the Base58 encoding scheme.
+/// Usage:
+///  ```
+///  String encodedBase58 = Base58Codec.encodeWithChecksum(<int>[1, 2, 3, 4, 5]);
+///  String encodedBase58 = Base58Codec.encode(<int>[1, 2, 3, 4, 5]);
+///  Uint8List decodedBase58 = Base58Codec.decode("aXQWBu6W");
+///  ```
+export 'src/codecs/base/base58_codec.dart';
+
+/// Classes designed for encoding data using the Bech32 encoding scheme.
+/// Usage:
+///  ```
+///  String encodedBech32 = Bech32Codec.encode(Bech32Pair(hrp: 'crypto', data: base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0=')));
+///  Bech32Pair decodedBech32 = Bech32Codec.decode("crypto19vv6y4jchws9zt8sme4culxtku8dajndgyhdm2");
+///
+///  String encodedSegwit = SegwitBech32Codec.encode('bc', 0, base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0='));
+///  Uint8List decodedSegwit = SegwitBech32Codec.decode("bc1q9vv6y4jchws9zt8sme4culxtku8dajnd5jq660");
+///  ```
+export 'src/codecs/bech32/export.dart';
+
 /// Defines available CBOR data structures
 export 'src/codecs/cbor/export.dart';
+
+/// The [HexCodec] class is designed for encoding and decoding data using the hexadecimal encoding scheme.
+/// Usage:
+///  ```
+///  String encodedHex = HexCodec.encode(<int>[1, 2, 3, 4, 5]);
+///  Uint8List decodedHex = HexCodec.decode("0102030405");
+///  ```
+export 'src/codecs/hex/hex_codec.dart';
+
+///  Provides static utility methods for encoding and decoding data using the Recursive Length Prefix (RLP) encoding scheme.
+///  Usage:
+///   ```
+///   Uint8List encodedRlp = RLP.encode(RLPBytes());
+///   IRLPElement decodedRlp = RLP.decode(encodedRlp);
+///   ```
+export 'src/codecs/rlp/rlp_codec.dart';
 
 /// Defines Uniform Resource (UR) object, containing CBOR encoded data from QR code.
 /// Usage:

--- a/lib/src/codecs/base/base58_codec.dart
+++ b/lib/src/codecs/base/base58_codec.dart
@@ -1,0 +1,104 @@
+// Class was shaped by the influence of several key sources including:
+// "blockchain_utils" - Copyright (c) 2010 Mohsen
+// https://github.com/mrtnetwork/blockchain_utils/.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:typed_data';
+
+import 'package:codec_utils/src/utils/big_int_utils.dart';
+import 'package:crypto/crypto.dart';
+
+/// The [Base58Codec] class is designed for encoding data using the Base58 encoding scheme.
+class Base58Codec {
+  static const String _bitcoinCheckAlphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+  static String encodeWithChecksum(Uint8List dataBytes) {
+    List<int> checksum = _computeChecksum(dataBytes);
+    List<int> dataWithChecksum = List<int>.from(<int>[...dataBytes, ...checksum]);
+    return encode(Uint8List.fromList(dataWithChecksum));
+  }
+
+  static String encode(Uint8List dataBytes) {
+    String alphabet = _bitcoinCheckAlphabet;
+
+    BigInt value = BigIntUtils.decode(dataBytes);
+    String enc = '';
+    while (value > BigInt.zero) {
+      BigInt dividedValue = value ~/ BigInt.from(58);
+      BigInt modulatedValue = value % BigInt.from(58);
+
+      value = dividedValue;
+      enc = alphabet[modulatedValue.toInt()] + enc;
+    }
+
+    int zero = 0;
+    for (int byte in dataBytes) {
+      if (byte == 0) {
+        zero++;
+      } else {
+        break;
+      }
+    }
+    final int leadingZeros = dataBytes.length - (dataBytes.length - zero);
+
+    return (alphabet[0] * leadingZeros) + enc;
+  }
+
+  static Uint8List decode(String data) {
+    String alphabet = _bitcoinCheckAlphabet;
+    BigInt val = BigInt.zero;
+
+    for (int i = 0; i < data.length; i++) {
+      String c = data[data.length - 1 - i];
+      int charIndex = alphabet.indexOf(c);
+      if (charIndex == -1) {
+        throw const FormatException('Invalid character in Base58 string');
+      }
+      val += BigInt.from(charIndex) * BigInt.from(58).pow(i);
+    }
+
+    Uint8List bytes = BigIntUtils.changeToBytes(val);
+
+    int padLen = 0;
+    for (int i = 0; i < data.length; i++) {
+      if (data[i] == alphabet[0]) {
+        padLen++;
+      } else {
+        break;
+      }
+    }
+
+    return Uint8List.fromList(<int>[...List<int>.filled(padLen, 0), ...bytes]);
+  }
+
+  static List<int> _computeChecksum(Uint8List dataBytes) {
+    Uint8List doubleSha256Digest = Uint8List.fromList(sha256.convert(sha256.convert(dataBytes).bytes).bytes);
+    return doubleSha256Digest.sublist(0, 4);
+  }
+}

--- a/lib/src/codecs/bech32/bech32_codec.dart
+++ b/lib/src/codecs/bech32/bech32_codec.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:bech32/bech32.dart';
+import 'package:codec_utils/src/codecs/bech32/bech32_pair.dart';
+
+/// The [Bech32Codec] class is designed for encoding data using the Bech32 encoding scheme.
+/// The specification for Bech32 encoding can be found in BIP-0173 and BIP-0350:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+class Bech32Codec {
+  static String encode(Bech32Pair bech32pair) {
+    Uint8List convertedData = _convertBits(bech32pair.data, 8, 5);
+    // TODO(dominik): Implement custom Bech32 encoding
+    return bech32.encode(Bech32(bech32pair.hrp, convertedData));
+  }
+
+  static Bech32Pair decode(String bechAddress) {
+    Bech32 decodedBech32 = bech32.decode(bechAddress);
+    // TODO(dominik): Implement custom Bech32 decoding
+    Uint8List convertedData = _convertBits(decodedBech32.data, 5, 8, padBool: false);
+
+    return Bech32Pair(data: convertedData, hrp: decodedBech32.hrp);
+  }
+
+  static Uint8List _convertBits(
+    List<int> data,
+    int startBitIndex,
+    int endBitIndex, {
+    bool padBool = true,
+  }) {
+    int acc = 0;
+    int bits = 0;
+    List<int> result = <int>[];
+    int maxV = (1 << endBitIndex) - 1;
+
+    for (int v in data) {
+      if (v < 0 || (v >> startBitIndex) != 0) {
+        throw Exception('Got address byte smaller than zero or greater than 2^startBitIndex');
+      }
+      acc = (acc << startBitIndex) | v;
+      bits += startBitIndex;
+      while (bits >= endBitIndex) {
+        bits -= endBitIndex;
+        result.add((acc >> bits) & maxV);
+      }
+    }
+
+    if (padBool) {
+      if (bits > 0) {
+        result.add((acc << (endBitIndex - bits)) & maxV);
+      }
+    } else if (bits >= startBitIndex) {
+      throw Exception('Illegal zero padding');
+    } else if (((acc << (endBitIndex - bits)) & maxV) != 0) {
+      throw Exception('Non zero');
+    }
+
+    return Uint8List.fromList(result);
+  }
+}

--- a/lib/src/codecs/bech32/bech32_pair.dart
+++ b/lib/src/codecs/bech32/bech32_pair.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+
+/// Class representing a Bech32 encoded pair
+class Bech32Pair extends Equatable {
+  /// The human-readable part (hrp) of the Bech32 encoded pair.
+  final String hrp;
+
+  /// The data part of the Bech32 encoded pair.
+  final Uint8List data;
+
+  /// Creates a [Bech32Pair] with the given [hrp] and [data].
+  const Bech32Pair({
+    required this.hrp,
+    required this.data,
+  });
+
+  @override
+  List<Object?> get props => <Object?>[hrp, data];
+}

--- a/lib/src/codecs/bech32/export.dart
+++ b/lib/src/codecs/bech32/export.dart
@@ -1,0 +1,3 @@
+export 'bech32_codec.dart';
+export 'bech32_pair.dart';
+export 'segwit_bech32_codec.dart';

--- a/lib/src/codecs/bech32/segwit_bech32_codec.dart
+++ b/lib/src/codecs/bech32/segwit_bech32_codec.dart
@@ -1,0 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:bech32/bech32.dart';
+
+/// The [SegwitBech32Codec] class is designed for encoding Segregated Witness (SegWit) addresses using the Bech32 encoding scheme,
+/// as outlined in BIP-0173 and further refined for SegWit in BIP-0174:
+/// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+/// https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+class SegwitBech32Codec {
+  static String encode(String hrp, int witnessVersion, List<int> witnessProgram) {
+    // TODO(dominik): Implement custom Segwit encoder
+    return const SegwitCodec().encode(Segwit(hrp, witnessVersion, witnessProgram));
+  }
+
+  static Uint8List decode(String bechAddress) {
+    // TODO(dominik): Implement custom Segwit decoder
+    return Uint8List.fromList(const SegwitCodec().decode(bechAddress).program);
+  }
+}

--- a/lib/src/codecs/cbor/ethereum/cbor_eth_sign_request.dart
+++ b/lib/src/codecs/cbor/ethereum/cbor_eth_sign_request.dart
@@ -66,7 +66,7 @@ class CborEthSignRequest extends ACborTaggedObject {
       dataType: cborDataType != null ? CborEthSignDataType.fromCborIndex(cborDataType.value) : CborEthSignDataType.fromCborIndex(1),
       chainId: cborChainId?.value ?? 1,
       derivationPath: CborCryptoKeypath.fromCborMap(cborDerivationPath),
-      address: cborAddress != null ? '0x${HexCodec.encode(cborAddress.bytes)}' : null,
+      address: cborAddress != null ? HexCodec.encode(cborAddress.bytes, includePrefixBool: true) : null,
       origin: cborOrigin?.toString(),
     );
   }

--- a/lib/src/codecs/hex/hex_codec.dart
+++ b/lib/src/codecs/hex/hex_codec.dart
@@ -3,14 +3,14 @@ import 'dart:typed_data';
 /// The [HexCodec] class is designed for encoding and decoding data using the hexadecimal encoding scheme.
 class HexCodec {
   /// Encodes the given [data] as a hexadecimal string.
-  static String encode(List<int> data, {bool lowercaseBool = true}) {
+  static String encode(List<int> data, {bool lowercaseBool = true, bool includePrefixBool = false}) {
     List<String> hexString = data.map((int e) => e.toRadixString(16).padLeft(2, '0')).toList();
     String hexData = hexString.join();
 
     if (lowercaseBool) {
-      return hexData.toLowerCase();
+      return includePrefixBool ? '0x${hexData.toLowerCase()}' : hexData.toLowerCase();
     } else {
-      return hexData.toUpperCase();
+      return includePrefixBool ? '0x${hexData.toUpperCase()}' : hexData.toUpperCase();
     }
   }
 
@@ -20,6 +20,10 @@ class HexCodec {
     if (hex.startsWith('0x')) {
       tmpHex = hex.substring(2);
     }
+    if (tmpHex.length % 2 != 0) {
+      tmpHex = '0$tmpHex';
+    }
+
     List<String> hexString = tmpHex.split('');
     List<String> hexPairs = <String>[];
 
@@ -32,5 +36,15 @@ class HexCodec {
     Uint8List hexPairsUint8List = Uint8List.fromList(hexPairsInt);
 
     return hexPairsUint8List;
+  }
+
+  /// Returns whether the given [hex] string is a valid hexadecimal string.
+  static bool isHex(String hex) {
+    try {
+      decode(hex);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/lib/src/codecs/rlp/rlp_codec.dart
+++ b/lib/src/codecs/rlp/rlp_codec.dart
@@ -1,0 +1,118 @@
+// Class was shaped by the influence of JavaScript key sources including:
+// https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
+//
+// Mozilla Public License Version 2.0
+
+import 'dart:typed_data';
+
+import 'package:codec_utils/src/codecs/hex/hex_codec.dart';
+import 'package:codec_utils/src/utils/big_int_utils.dart';
+import 'package:equatable/equatable.dart';
+
+part 'types/i_rlp_element.dart';
+
+part 'types/rlp_bytes.dart';
+
+part 'types/rlp_list.dart';
+
+part 'types/rlp_remainder_wrapper.dart';
+
+part 'rlp_utils.dart';
+
+/// Provides static utility methods for encoding and decoding data using the Recursive Length Prefix (RLP) encoding scheme.
+/// RLP is a serialization technique used primarily in the Ethereum protocol to encode nested arrays of binary data,
+/// and it's crucial for encoding transactions, blocks, and other structured data.
+class RLPCodec {
+  /// Encodes an [IRLPElement] into a [Uint8List]. This method allows for converting structured data that implements
+  /// the [IRLPElement] interface into a format suitable for transmission or storage.
+  static Uint8List encode(IRLPElement input) {
+    return input.encode();
+  }
+
+  /// Decodes a [Uint8List] into an [IRLPElement]. This method is responsible for interpreting RLP-encoded byte data,
+  /// reconstructing the original structured data from its serialized form.
+  static IRLPElement decode(Uint8List input) {
+    RLPRemainderWrapper decodedRLP = _decode(input);
+    if (decodedRLP.remainder.isNotEmpty) {
+      throw Exception('Invalid RLP: input was not fully decoded');
+    }
+
+    return decodedRLP.data;
+  }
+
+  /// Contains a functionality to decode RLP-encoded data incrementally, returning the decoded element along with the remaining data.
+  static RLPRemainderWrapper _decode(Uint8List input) {
+    int firstByte = input[0];
+
+    if (firstByte <= 0x7f) {
+      // Single byte, same as itself
+      return RLPRemainderWrapper(data: RLPBytes(input.sublist(0, 1)), remainder: input.sublist(1));
+    } else if (firstByte <= 0xb7) {
+      // String with length 0-55 bytes
+      int length = firstByte - 0x7f;
+      Uint8List data = firstByte == 128 ? Uint8List(0) : input.sublist(1, length);
+      if (length == 2 && data[0] < 128) {
+        throw Exception('Invalid RLP encoding: invalid prefix, single byte < 128 are not prefixed');
+      }
+
+      return RLPRemainderWrapper(data: RLPBytes(data), remainder: input.sublist(length));
+    } else if (firstByte <= 0xbf) {
+      // String with length > 55 bytes
+      int lengthOfLength = firstByte - 0xb6;
+      if (input.length - 1 < lengthOfLength) {
+        throw Exception('Invalid RLP: not enough bytes for string length');
+      }
+      int length = _decodeLength(input.sublist(1, lengthOfLength));
+      if (length <= 55) {
+        throw Exception('Invalid RLP: expected string length to be greater than 55');
+      }
+
+      return RLPRemainderWrapper(
+        data: RLPBytes(input.sublist(lengthOfLength, length + lengthOfLength)),
+        remainder: input.sublist(length + lengthOfLength),
+      );
+    } else if (firstByte <= 0xf7) {
+      // List with total payload < 55 bytes
+      int length = firstByte - 0xbf;
+      Uint8List innerRemainder = input.sublist(1, length);
+      List<IRLPElement> decoded = <IRLPElement>[];
+      while (innerRemainder.isNotEmpty) {
+        RLPRemainderWrapper decodedElement = _decode(innerRemainder);
+        decoded.add(decodedElement.data);
+        innerRemainder = decodedElement.remainder;
+      }
+
+      return RLPRemainderWrapper(data: RLPList(decoded), remainder: input.sublist(length));
+    } else {
+      // List with total payload >= 55 bytes
+      int lengthOfLength = firstByte - 0xf6;
+      int length = _decodeLength(input.sublist(1, lengthOfLength));
+      if (length < 56) {
+        throw Exception('Invalid RLP: encoded list too short');
+      }
+      int totalLength = lengthOfLength + length;
+      if (totalLength > input.length) {
+        throw Exception('Invalid RLP: total length is larger than the data');
+      }
+
+      Uint8List innerRemainder = input.sublist(lengthOfLength, totalLength);
+      List<IRLPElement> decoded = <IRLPElement>[];
+
+      while (innerRemainder.isNotEmpty) {
+        RLPRemainderWrapper decodedElement = _decode(innerRemainder);
+        decoded.add(decodedElement.data);
+        innerRemainder = decodedElement.remainder;
+      }
+
+      return RLPRemainderWrapper(data: RLPList(decoded), remainder: input.sublist(totalLength));
+    }
+  }
+
+  /// Decodes the encoded length of a data element from a given RLP-encoded byte array.
+  static int _decodeLength(Uint8List v) {
+    if (v[0] == 0) {
+      throw Exception('Invalid RLP: extra zeros');
+    }
+    return int.parse(HexCodec.encode(v), radix: 16);
+  }
+}

--- a/lib/src/codecs/rlp/rlp_utils.dart
+++ b/lib/src/codecs/rlp/rlp_utils.dart
@@ -1,0 +1,45 @@
+// Class was shaped by the influence of several key sources including:
+// "rlp" Copyright (c) 2018 Max Holman <max@holmn.com>
+// https://github.com/maxholman/rlp/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+part of 'rlp_codec.dart';
+
+/// A utility class providing static methods related to the Recursive Length Prefix (RLP) encoding.
+class RLPUtils {
+  /// Encodes the length of a data element as part of the RLP encoding process. This method is used to determine
+  /// how many bytes are needed to represent the length of the data and to prepend the appropriate prefix according
+  /// to the RLP specification.
+  static Uint8List encodeLength(int length, int offset) {
+    if (length < 56) {
+      return Uint8List.fromList(<int>[length + offset]);
+    } else {
+      Uint8List binaryLength = _convertLengthToBytes(length);
+      return Uint8List.fromList(<int>[binaryLength.length + offset + 55, ...binaryLength]);
+    }
+  }
+
+  /// Converts the specified length to a list of bytes.
+  static Uint8List _convertLengthToBytes(int length) {
+    if (length == 0) {
+      return Uint8List(0);
+    }
+    return Uint8List.fromList(<int>[..._convertLengthToBytes(length ~/ 256), (length % 256)]);
+  }
+}

--- a/lib/src/codecs/rlp/types/i_rlp_element.dart
+++ b/lib/src/codecs/rlp/types/i_rlp_element.dart
@@ -1,0 +1,13 @@
+part of '../rlp_codec.dart';
+
+/// An interface class representing an element that can be encoded using the Recursive Length Prefix (RLP) encoding scheme.
+/// RLP is primarily used in Ethereum for encoding structured data (like transactions and blocks) into a byte array,
+/// facilitating data serialization and deserialization.
+///
+/// Subclasses of [IRLPElement] should implement the [encode] method to specify how the element should be encoded
+/// into a [Uint8List] according to RLP specifications.
+abstract class IRLPElement {
+  /// Encodes this element into a `Uint8List` using the RLP encoding scheme.
+  /// Implement this method to define how each specific subclass should be encoded.
+  Uint8List encode();
+}

--- a/lib/src/codecs/rlp/types/rlp_bytes.dart
+++ b/lib/src/codecs/rlp/types/rlp_bytes.dart
@@ -1,0 +1,47 @@
+// Class was shaped by the influence of JavaScript key sources including:
+// https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
+//
+// Mozilla Public License Version 2.0
+part of '../rlp_codec.dart';
+
+/// Represents a byte array element that can be encoded using the Recursive Length Prefix (RLP) encoding scheme.
+class RLPBytes extends Equatable implements IRLPElement {
+  /// The byte data to be encoded.
+  final Uint8List data;
+
+  /// Constructs an [RLPBytes] instance directly from [Uint8List] data.
+  const RLPBytes(this.data);
+
+  /// Constructs an [RLPBytes] instance from [BigInt] data.
+  RLPBytes.fromBigInt(BigInt value) : data = BigIntUtils.changeToBytes(value);
+
+  /// Constructs an [RLPBytes] instance from HEX data.
+  RLPBytes.fromHex(String value) : data = HexCodec.decode(value);
+
+  /// Constructs an empty [RLPBytes] instance
+  RLPBytes.empty() : data = Uint8List(0);
+
+  /// Encodes the byte array into RLP format. If the data is a single byte less than "0x80", it returns the data directly.
+  /// Otherwise, it prepends the length of the data to the data itself, adjusting for RLP encoding requirements.
+  @override
+  Uint8List encode() {
+    if (data.length == 1 && data.first < 128) {
+      return data;
+    } else {
+      return Uint8List.fromList(<int>[...RLPUtils.encodeLength(data.length, 128), ...data]);
+    }
+  }
+
+  /// Converts the byte array to a [BigInt].
+  BigInt toBigInt() {
+    return BigIntUtils.decode(data);
+  }
+
+  /// Converts the byte array to a HEX string.
+  String toHex() {
+    return HexCodec.encode(data, includePrefixBool: true);
+  }
+
+  @override
+  List<Object?> get props => <Object>[data];
+}

--- a/lib/src/codecs/rlp/types/rlp_list.dart
+++ b/lib/src/codecs/rlp/types/rlp_list.dart
@@ -1,0 +1,56 @@
+// Class was shaped by the influence of JavaScript key sources including:
+// https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
+//
+// Mozilla Public License Version 2.0
+part of '../rlp_codec.dart';
+
+/// Represents a list of RLP-encoded elements, allowing for the encoding of structured data using
+/// the Recursive Length Prefix (RLP) encoding scheme. This class is useful for handling collections of RLP elements.
+class RLPList extends Equatable implements IRLPElement {
+  /// The list of RLP elements that this [RLPList] encapsulates.
+  final List<IRLPElement> data;
+
+  /// Constructs an [RLPList] from a list of [IRLPElement] items.
+  const RLPList(this.data);
+
+  /// Encodes the entire list of RLP elements into a single [Uint8List] following RLP encoding rules,
+  /// which involves encoding each element and then combining them with the overall length prefix.
+  @override
+  Uint8List encode() {
+    BytesBuilder output = BytesBuilder();
+    for (IRLPElement rlpElement in data) {
+      output.add(rlpElement.encode());
+    }
+    return Uint8List.fromList(<int>[...RLPUtils.encodeLength(output.length, 192), ...output.toBytes()]);
+  }
+
+  /// Retrieves a [BigInt] from a specific index in the list,
+  /// assuming the element at that index is of type [RLPBytes].
+  BigInt getBigInt(int index) {
+    return (data[index] as RLPBytes).toBigInt();
+  }
+
+  /// Retrieves a HEX string from a specific index in the list,
+  /// assuming the element at that index is of type [RLPBytes].
+  String getHex(int index) {
+    return (data[index] as RLPBytes).toHex();
+  }
+
+  /// Retrieves an [RLPList] from a specific index in the list,
+  /// assuming the element at that index is of type [RLPList].
+  RLPList getRLPList(int index) {
+    return data[index] as RLPList;
+  }
+
+  /// Retrieves an [Uint8List] from a specific index in the list,
+  /// assuming the element at that index is of type [RLPBytes].
+  Uint8List getUint8List(int index) {
+    return (data[index] as RLPBytes).data;
+  }
+
+  /// Returns the number of elements in the [RLPList].
+  int get length => data.length;
+
+  @override
+  List<Object?> get props => <Object>[data];
+}

--- a/lib/src/codecs/rlp/types/rlp_remainder_wrapper.dart
+++ b/lib/src/codecs/rlp/types/rlp_remainder_wrapper.dart
@@ -1,0 +1,25 @@
+// Class was shaped by the influence of JavaScript key sources including:
+// https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
+//
+// Mozilla Public License Version 2.0
+part of '../rlp_codec.dart';
+
+/// Wraps an RLP-encoded element along with remainder data that was a part of the initial decoding process.
+/// This class handles cases where RLP data is parsed incrementally and there might be leftover bytes after parsing the main content.
+class RLPRemainderWrapper extends Equatable {
+  /// The RLP element that has been decoded.
+  final IRLPElement data;
+
+  /// The remainder of the data that was included in the initial RLP decoding.
+  /// This can include extra bytes that follow the primary encoded element, which might be part of subsequent encodings.
+  final Uint8List remainder;
+
+  /// Constructs an [RLPRemainderWrapper] with the specified decoded RLP element and the remainder of the data.
+  const RLPRemainderWrapper({
+    required this.data,
+    required this.remainder,
+  });
+
+  @override
+  List<Object?> get props => <Object>[data, remainder];
+}

--- a/lib/src/utils/big_int_utils.dart
+++ b/lib/src/utils/big_int_utils.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+class BigIntUtils {
+  static Uint8List changeToBytes(BigInt value, {int? length, Endian order = Endian.big}) {
+    int byteLength = length ?? _calculateByteLength(value);
+
+    BigInt updatedValue = value;
+    BigInt bigMaskEight = BigInt.from(0xff);
+    if (updatedValue == BigInt.zero) {
+      return Uint8List.fromList(List<int>.filled(byteLength, 0));
+    }
+    List<int> byteList = List<int>.filled(byteLength, 0);
+    for (int i = 0; i < byteLength; i++) {
+      byteList[byteLength - i - 1] = (updatedValue & bigMaskEight).toInt();
+      updatedValue = updatedValue >> 8;
+    }
+
+    if (order == Endian.little) {
+      byteList = byteList.reversed.toList();
+    }
+
+    return Uint8List.fromList(byteList);
+  }
+
+  static BigInt decode(List<int> bytes, {int? bitLength, Endian order = Endian.big}) {
+    List<int> tmpBytes = bytes;
+    if (order == Endian.little) {
+      tmpBytes = List<int>.from(bytes.reversed.toList());
+    }
+
+    int bytesBitLength = tmpBytes.length * 8;
+
+    BigInt result = BigInt.zero;
+    for (int i = 0; i < tmpBytes.length; i++) {
+      result += BigInt.from(tmpBytes[tmpBytes.length - i - 1]) << (8 * i);
+    }
+
+    if (bitLength != null && bytesBitLength >= bitLength) {
+      result >>= bytesBitLength - bitLength;
+    }
+    return result;
+  }
+
+  static int _calculateByteLength(BigInt value) {
+    String valueHex = value.toRadixString(16);
+    int byteLength = (valueHex.length + 1) ~/ 2;
+    return byteLength;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: codec_utils
 description: "Dart package containing utility methods for data encoding and decoding"
-version: 0.0.2
+version: 0.0.3
 publish_to: none
 
 environment:
@@ -18,6 +18,10 @@ dependencies:
   # Implementations of SHA, MD5, and HMAC cryptographic functions.
   # https://pub:dev/packages/crypto
   crypto: 3.0.3
+
+  # Library implementing Bitcoins BIP173 (Bech32 encoding) specification in a Flutter friendly fashion.
+  # https://pub.dev/packages/bech32
+  bech32: 0.2.2
 
   # CBOR library for Dart. An RFC8949 compliant encoding/decoding CBOR implementation.
   # https://pub.dev/packages/cbor

--- a/test/unit/codecs/base/base58_codec_test.dart
+++ b/test/unit/codecs/base/base58_codec_test.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/src/codecs/base/base58_codec.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of Base58Codec.encode()', () {
+    test('Should [return String] encoded by Base58', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('Q1JZUFRP');
+
+      // Act
+      String actualBase58Result = Base58Codec.encode(actualDataToEncode);
+
+      // Assert
+      String expectedBase58Result = 'aXQWBu6W';
+
+      expect(actualBase58Result, expectedBase58Result);
+    });
+
+    test('Should [return String] encoded by Base58 (with checksum)', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('Q1JZUFRP');
+
+      // Act
+      String actualBase58Result = Base58Codec.encodeWithChecksum(actualDataToEncode);
+
+      // Assert
+      String expectedBase58Result = '4nNW8qCqV3i7VY';
+
+      expect(actualBase58Result, expectedBase58Result);
+    });
+  });
+
+  group('Tests of Base58Codec.decode()', () {
+    test('Should [return String] encoded by Base58', () {
+      // Arrange
+      String actualBase58 = 'aXQWBu6W';
+
+      // Act
+      Uint8List actualDecodedData = Base58Codec.decode(actualBase58);
+
+      // Assert
+      Uint8List expectedDecodedData = base64Decode('Q1JZUFRP');
+
+      expect(actualDecodedData, expectedDecodedData);
+    });
+
+    test('Should [return String] encoded by Base58 (with checksum)', () {
+      // Arrange
+      String actualBase58 = '4nNW8qCqV3i7VY';
+
+      // Act
+      Uint8List actualDecodedData = Base58Codec.decode(actualBase58);
+
+      // Assert
+      Uint8List expectedDecodedData = base64Decode('Q1JZUFRPndAu1w==');
+
+      expect(actualDecodedData, expectedDecodedData);
+    });
+  });
+}

--- a/test/unit/codecs/bech32/bech32_codec_test.dart
+++ b/test/unit/codecs/bech32/bech32_codec_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:codec_utils/src/codecs/bech32/bech32_codec.dart';
+import 'package:codec_utils/src/codecs/bech32/bech32_pair.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of Bech32Codec.encode()', () {
+    test('Should [return String] encoded by Bech32', () {
+      // Arrange
+      Bech32Pair actualBech32Pair = Bech32Pair(hrp: 'crypto', data: base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0='));
+
+      // Act
+      String actualEncodedData = Bech32Codec.encode(actualBech32Pair);
+
+      // Assert
+      String expectedEncodedData = 'crypto19vv6y4jchws9zt8sme4culxtku8dajndgyhdm2';
+
+      expect(actualEncodedData, expectedEncodedData);
+    });
+  });
+
+  group('Tests of Bech32Codec.decode()', () {
+    test('Should [return Bech32Pair] decoded by Bech32', () {
+      // Arrange
+      String actualDataToDecode = 'crypto19vv6y4jchws9zt8sme4culxtku8dajndgyhdm2';
+
+      // Act
+      Bech32Pair actualBech32Pair = Bech32Codec.decode(actualDataToDecode);
+
+      // Assert
+      Bech32Pair expectedBech32Pair = Bech32Pair(hrp: 'crypto', data: base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0='));
+
+      expect(actualBech32Pair, expectedBech32Pair);
+    });
+  });
+}

--- a/test/unit/codecs/bech32/segwit_bech32_codec_test.dart
+++ b/test/unit/codecs/bech32/segwit_bech32_codec_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/src/codecs/bech32/segwit_bech32_codec.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of SegwitBech32Codec.encode()', () {
+    test('Should [return String] encoded by Bech32 (Segwit version)', () {
+      // Arrange
+      Uint8List actualDataToEncode = base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0=');
+
+      // Act
+      String actualEncodedData = SegwitBech32Codec.encode('bc', 0, actualDataToEncode);
+
+      // Assert
+      String expectedEncodedData = 'bc1q9vv6y4jchws9zt8sme4culxtku8dajnd5jq660';
+
+      expect(actualEncodedData, expectedEncodedData);
+    });
+  });
+
+  group('Tests of SegwitBech32Codec.decode()', () {
+    test('Should [return String] encoded by Bech32 (Segwit version)', () {
+      // Arrange
+      String actualDataToDecode = 'bc1q9vv6y4jchws9zt8sme4culxtku8dajnd5jq660';
+
+      // Act
+      Uint8List actualDecodedData = SegwitBech32Codec.decode(actualDataToDecode);
+
+      // Assert
+      Uint8List expectedDecodedData = base64Decode('KxmiVli7oFEs8N5rjnzLtw7eym0=');
+
+      expect(actualDecodedData, expectedDecodedData);
+    });
+  });
+}

--- a/test/unit/codecs/cbor/a_cbor_tagged_object_test.dart
+++ b/test/unit/codecs/cbor/a_cbor_tagged_object_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:cbor/cbor.dart';
 import 'package:codec_utils/codec_utils.dart';
-import 'package:codec_utils/src/codecs/hex/hex_codec.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/unit/codecs/hex/hex_codec_test.dart
+++ b/test/unit/codecs/hex/hex_codec_test.dart
@@ -11,11 +11,23 @@ void main() {
       '3132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F505152535455565758595A5B5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E';
 
   group('Tests of HexCodec.encode()', () {
-    test('Should [return UPPERCASE hexadecimal] from given bytes', () {
+    test('Should [return UPPERCASE hexadecimal] from given bytes (WITH 0x prefix)', () {
       Uint8List actualDataToEncode = asciiCodeBytes;
 
       // Act
-      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: false);
+      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: false, includePrefixBool: true);
+
+      // Assert
+      String expectedHexResult = '0x$hexUppercase';
+
+      expect(actualHexResult, expectedHexResult);
+    });
+
+    test('Should [return UPPERCASE hexadecimal] from given bytes (WITHOUT 0x prefix)', () {
+      Uint8List actualDataToEncode = asciiCodeBytes;
+
+      // Act
+      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: false, includePrefixBool: false);
 
       // Assert
       String expectedHexResult = hexUppercase;
@@ -23,11 +35,23 @@ void main() {
       expect(actualHexResult, expectedHexResult);
     });
 
-    test('Should [return LOWERCASE hexadecimal] from given bytes', () {
+    test('Should [return LOWERCASE hexadecimal] from given bytes (WITH 0x prefix', () {
       Uint8List actualDataToEncode = asciiCodeBytes;
 
       // Act
-      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: true);
+      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: true, includePrefixBool: true);
+
+      // Assert
+      String expectedHexResult = '0x$hexLowercase';
+
+      expect(actualHexResult, expectedHexResult);
+    });
+
+    test('Should [return LOWERCASE hexadecimal] from given bytes (WITHOUT 0x prefix)', () {
+      Uint8List actualDataToEncode = asciiCodeBytes;
+
+      // Act
+      String actualHexResult = HexCodec.encode(actualDataToEncode, lowercaseBool: true, includePrefixBool: false);
 
       // Assert
       String expectedHexResult = hexLowercase;
@@ -37,7 +61,7 @@ void main() {
   });
 
   group('Tests of HexCodec.decode()', () {
-    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [with 0x prefix]', () {
+    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [WITH 0x prefix]', () {
       // Arrange
       String actualHexToDecode = hexUppercase;
 
@@ -50,7 +74,7 @@ void main() {
       expect(actualDecodedHexResult, expectedDecodedHexResult);
     });
 
-    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [without 0x prefix]', () {
+    test('Should [return Uint8List] decoded from given [UPPERCASE hexadecimal] [WITHOUT 0x prefix]', () {
       // Arrange
       String actualHexToDecode = hexUppercase;
 
@@ -63,7 +87,7 @@ void main() {
       expect(actualDecodedHexResult, expectedDecodedHexResult);
     });
 
-    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [with 0x prefix]', () {
+    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [WITH 0x prefix]', () {
       // Arrange
       String actualHexToDecode = hexLowercase;
 
@@ -76,7 +100,7 @@ void main() {
       expect(actualDecodedHexResult, expectedDecodedHexResult);
     });
 
-    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [without 0x prefix]', () {
+    test('Should [return Uint8List] decoded from given [LOWERCASE hexadecimal] [WITHOUT 0x prefix]', () {
       // Arrange
       String actualHexToDecode = hexLowercase;
 
@@ -87,6 +111,73 @@ void main() {
       Uint8List expectedDecodedHexResult = asciiCodeBytes;
 
       expect(actualDecodedHexResult, expectedDecodedHexResult);
+    });
+  });
+
+  group('Tests of HexCodec.isHex()', () {
+    test('Should [return TRUE] if given value is [UPPERCASE hexadecimal] [WITH 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = '0x$hexUppercase';
+
+      // Act
+      bool actualHexBool = HexCodec.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [UPPERCASE hexadecimal] [WITHOUT 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = hexUppercase;
+
+      // Act
+      bool actualHexBool = HexCodec.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [LOWERCASE hexadecimal] [WITH 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = '0x$hexLowercase';
+
+      // Act
+      bool actualHexBool = HexCodec.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return TRUE] if given value is [LOWERCASE hexadecimal] [WITHOUT 0x prefix]', () {
+      // Arrange
+      String actualHexToCheck = hexLowercase;
+
+      // Act
+      bool actualHexBool = HexCodec.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = true;
+
+      expect(actualHexBool, expectedHexBool);
+    });
+
+    test('Should [return FALSE] if given value is [NOT hexadecimal]', () {
+      // Arrange
+      String actualHexToCheck = 'random string';
+
+      // Act
+      bool actualHexBool = HexCodec.isHex(actualHexToCheck);
+
+      // Assert
+      bool expectedHexBool = false;
+
+      expect(actualHexBool, expectedHexBool);
     });
   });
 }

--- a/test/unit/codecs/rlp/rlp_coder_test.dart
+++ b/test/unit/codecs/rlp/rlp_coder_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of RLPCoder.encode()', () {
+    test('Should [return bytes] representing RLP-encoded bytes', () {
+      // Arrange
+      RLPList actualRLPList = RLPList(<IRLPElement>[
+        RLPBytes(Uint8List.fromList(<int>[1, 2, 3, 4, 5])),
+        RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21])),
+        RLPList(<IRLPElement>[
+          RLPBytes(Uint8List.fromList(<int>[5, 4, 3, 2, 1])),
+          RLPBytes(Uint8List.fromList(<int>[21, 205, 91, 7])),
+        ]),
+      ]);
+
+      // Act
+      Uint8List actualRLPBytes = RLPCodec.encode(actualRLPList);
+
+      // Assert
+      Uint8List expectedRLPBytes = base64Decode('14UBAgMEBYQHW80Vy4UFBAMCAYQVzVsH');
+
+      expect(actualRLPBytes, expectedRLPBytes);
+    });
+  });
+
+  group('Tests of RLPCoder.decode()', () {
+    test('Should [return RLPList] from given RLP-encoded bytes', () {
+      // Arrange
+      Uint8List actualRLPBytes = base64Decode('14UBAgMEBYQHW80Vy4UFBAMCAYQVzVsH');
+
+      // Act
+      IRLPElement actualRLPElement = RLPCodec.decode(actualRLPBytes);
+
+      // Assert
+      IRLPElement expectedRLPElement = RLPList(<IRLPElement>[
+        RLPBytes(Uint8List.fromList(<int>[1, 2, 3, 4, 5])),
+        RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21])),
+        RLPList(<IRLPElement>[
+          RLPBytes(Uint8List.fromList(<int>[5, 4, 3, 2, 1])),
+          RLPBytes(Uint8List.fromList(<int>[21, 205, 91, 7])),
+        ]),
+      ]);
+
+      expect(actualRLPElement, expectedRLPElement);
+    });
+
+    test('Should [return RLPBytes] from given RLP-encoded bytes', () {
+      // Arrange
+      Uint8List actualRLPBytes = base64Decode('hQECAwQF');
+
+      // Act
+      IRLPElement actualRLPElement = RLPCodec.decode(actualRLPBytes);
+
+      // Assert
+      IRLPElement expectedRLPElement = RLPBytes(Uint8List.fromList(<int>[1, 2, 3, 4, 5]));
+
+      expect(actualRLPElement, expectedRLPElement);
+    });
+  });
+}

--- a/test/unit/codecs/rlp/rlp_utils_test.dart
+++ b/test/unit/codecs/rlp/rlp_utils_test.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of RLPUtils.encodeLength()', () {
+    test('Should [return encoded length] for [length < 56]', () {
+      // Arrange
+      int actualLength = 55;
+      int actualOffset = 128;
+
+      // Act
+      Uint8List actualEncodedLength = RLPUtils.encodeLength(actualLength, actualOffset);
+
+      // Assert
+      Uint8List expectedEncodedLength = Uint8List.fromList(<int>[183]);
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
+
+    test('Should [return encoded length] for [length >= 56]', () {
+      // Arrange
+      int actualLength = 56;
+      int actualOffset = 128;
+
+      // Act
+      Uint8List actualEncodedLength = RLPUtils.encodeLength(actualLength, actualOffset);
+
+      // Assert
+      Uint8List expectedEncodedLength = Uint8List.fromList(<int>[184, 56]);
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
+
+    test('Should [return encoded length] for [length >= 256]', () {
+      // Arrange
+      int actualLength = 257;
+      int actualOffset = 128;
+
+      // Act
+      Uint8List actualEncodedLength = RLPUtils.encodeLength(actualLength, actualOffset);
+
+      // Assert
+      Uint8List expectedEncodedLength = Uint8List.fromList(<int>[185, 1, 1]);
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
+  });
+}

--- a/test/unit/codecs/rlp/types/rlp_bytes_test.dart
+++ b/test/unit/codecs/rlp/types/rlp_bytes_test.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of RLPBytes.fromBigInt() constructor', () {
+    test('Should [return RLPBytes] from given BigInt', () {
+      // Arrange
+      BigInt actualBigInt = BigInt.from(123456789);
+
+      // Act
+      RLPBytes actualRLPBytes = RLPBytes.fromBigInt(actualBigInt);
+
+      // Assert
+      RLPBytes expectedRLPBytes = RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21]));
+
+      expect(actualRLPBytes, expectedRLPBytes);
+    });
+  });
+
+  group('Tests of RLPBytes.fromHex() constructor', () {
+    test('Should [return RLPBytes] from given BigInt', () {
+      // Arrange
+      String actualHex = '0x075bcd15';
+
+      // Act
+      RLPBytes actualRLPBytes = RLPBytes.fromHex(actualHex);
+
+      // Assert
+      RLPBytes expectedRLPBytes = RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21]));
+
+      expect(actualRLPBytes, expectedRLPBytes);
+    });
+  });
+
+  group('Tests of RLPBytes.encode()', () {
+    test('Should [return bytes] representing RLP-encoded bytes', () {
+      // Arrange
+      RLPBytes rlpBytes = RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21]));
+
+      // Act
+      Uint8List actualBytes = rlpBytes.encode();
+
+      // Assert
+      Uint8List expectedBytes = Uint8List.fromList(<int>[132, 7, 91, 205, 21]);
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of RLPBytes.toBigInt()', () {
+    test('Should [return BigInt] from given RLPBytes', () {
+      // Arrange
+      RLPBytes actualRLPBytes = RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21]));
+
+      // Act
+      BigInt actualBigInt = actualRLPBytes.toBigInt();
+
+      // Assert
+      BigInt expectedBigInt = BigInt.from(123456789);
+
+      expect(actualBigInt, expectedBigInt);
+    });
+  });
+
+  group('Tests of RLPBytes.toHex()', () {
+    test('Should [return HEX] from given RLPBytes', () {
+      // Arrange
+      RLPBytes actualRLPBytes = RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21]));
+
+      // Act
+      String actualHex = actualRLPBytes.toHex();
+
+      // Assert
+      String expectedHex = '0x075bcd15';
+
+      expect(actualHex, expectedHex);
+    });
+  });
+}

--- a/test/unit/codecs/rlp/types/rlp_list_test.dart
+++ b/test/unit/codecs/rlp/types/rlp_list_test.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Arrange
+  RLPList actualRLPList = RLPList(<IRLPElement>[
+    RLPBytes(Uint8List.fromList(<int>[1, 2, 3, 4, 5])),
+    RLPBytes(Uint8List.fromList(<int>[7, 91, 205, 21])),
+    RLPList(<IRLPElement>[
+      RLPBytes(Uint8List.fromList(<int>[5, 4, 3, 2, 1])),
+      RLPBytes(Uint8List.fromList(<int>[21, 205, 91, 7])),
+    ]),
+  ]);
+
+  group('Tests of RLPList.encode()', () {
+    test('Should [return bytes] representing RLP-encoded list', () {
+      // Act
+      Uint8List actualRLPBytes = actualRLPList.encode();
+
+      // Assert
+      Uint8List expectedRLPBytes = base64Decode('14UBAgMEBYQHW80Vy4UFBAMCAYQVzVsH');
+
+      expect(actualRLPBytes, expectedRLPBytes);
+    });
+  });
+
+  group('Tests of RLPList.getBigInt()', () {
+    test('Should [return BigInt] from given index in RLPList', () {
+      // Act
+      BigInt actualBigInt = actualRLPList.getBigInt(1);
+
+      // Assert
+      BigInt expectedBigInt = BigInt.from(123456789);
+
+      expect(actualBigInt, expectedBigInt);
+    });
+  });
+
+  group('Tests of RLPList.getHex()', () {
+    test('Should [return HEX] from given index in RLPList', () {
+      // Act
+      String actualHex = actualRLPList.getHex(1);
+
+      // Assert
+      String expectedHex = '0x075bcd15';
+
+      expect(actualHex, expectedHex);
+    });
+  });
+
+  group('Tests of RLPList.getRLPList()', () {
+    test('Should [return RLPList] from given index in RLPList', () {
+      // Act
+      RLPList actualNestedRLPList = actualRLPList.getRLPList(2);
+
+      // Assert
+      RLPList expectedNestedRLPList = RLPList(<IRLPElement>[
+        RLPBytes(Uint8List.fromList(<int>[5, 4, 3, 2, 1])),
+        RLPBytes(Uint8List.fromList(<int>[21, 205, 91, 7])),
+      ]);
+
+      expect(actualNestedRLPList, expectedNestedRLPList);
+    });
+  });
+
+  group('Tests of RLPList.getUint8List()', () {
+    test('Should [return Uint8List] from given index in RLPList', () {
+      // Act
+      Uint8List actualUint8List = actualRLPList.getUint8List(0);
+
+      // Assert
+      Uint8List expectedUint8List = Uint8List.fromList(<int>[1, 2, 3, 4, 5]);
+
+      expect(actualUint8List, expectedUint8List);
+    });
+  });
+
+  group('Tests of RLPList.length getter', () {
+    test('Should [return length] of RLPList', () {
+      // Act
+      int actualLength = actualRLPList.length;
+
+      // Assert
+      int expectedLength = 3;
+
+      expect(actualLength, expectedLength);
+    });
+  });
+}

--- a/test/unit/utils/big_int_utils_test.dart
+++ b/test/unit/utils/big_int_utils_test.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/src/utils/big_int_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of BigIntUtils.changeToBytes()', () {
+    test('Should [return Endian.big bytes] constructed from given BigInt', () {
+      // Arrange
+      BigInt actualBigInt = BigInt.parse('1234567890');
+
+      // Act
+      Uint8List actualBytes = BigIntUtils.changeToBytes(actualBigInt);
+
+      // Assert
+      Uint8List expectedBytes = base64Decode('SZYC0g==');
+
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return padded Endian.big bytes] constructed from given BigInt and length', () {
+      // Arrange
+      BigInt actualBigInt = BigInt.parse('1234567890');
+
+      // Act
+      Uint8List actualBytes = BigIntUtils.changeToBytes(actualBigInt, length: 20);
+
+      // Assert
+      Uint8List expectedBytes = base64Decode('AAAAAAAAAAAAAAAAAAAAAEmWAtI=');
+
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return Endian.little bytes] constructed from given BigInt', () {
+      // Arrange
+      BigInt actualBigInt = BigInt.parse('1234567890');
+
+      // Act
+      Uint8List actualBytes = BigIntUtils.changeToBytes(actualBigInt, order: Endian.little);
+
+      // Assert
+      Uint8List expectedBytes = base64Decode('0gKWSQ==');
+
+      expect(actualBytes, expectedBytes);
+    });
+
+    test('Should [return padded Endian.little bytes] constructed from given BigInt and length', () {
+      // Arrange
+      BigInt actualBigInt = BigInt.parse('1234567890');
+
+      // Act
+      Uint8List actualBytes = BigIntUtils.changeToBytes(actualBigInt, length: 20, order: Endian.little);
+
+      // Assert
+      Uint8List expectedBytes = base64Decode('0gKWSQAAAAAAAAAAAAAAAAAAAAA=');
+
+      expect(actualBytes, expectedBytes);
+    });
+  });
+
+  group('Tests of BigIntUtils.decode()', () {
+    test('Should [return BigInt] constructed from given [Endian.big bytes]', () {
+      // Arrange
+      List<int> actualBytes = base64Decode('SZYC0g==');
+
+      // Act
+      BigInt actualBigInt = BigIntUtils.decode(actualBytes);
+
+      // Assert
+      BigInt expectedBigInt = BigInt.parse('1234567890');
+
+      expect(actualBigInt, expectedBigInt);
+    });
+
+    test('Should [return BigInt] constructed from given [Endian.little bytes]', () {
+      // Arrange
+      List<int> actualBytes = base64Decode('SZYC0g==');
+
+      // Act
+      BigInt actualBigInt = BigIntUtils.decode(actualBytes, order: Endian.little);
+
+      // Assert
+      BigInt expectedBigInt = BigInt.parse('3523384905');
+
+      expect(actualBigInt, expectedBigInt);
+    });
+  });
+}


### PR DESCRIPTION
The purpose of this branch is to import the encoders from the "cryptography_utils" package to separate elements related to blockchain, encryption and signing, from those related to bidirectional encoding and decoding operations.

List of changes:
- created "codecs/base" containing classes related to Base (Binary-to-ASCII) encoding/decoding (currently only for Base58)
- created "codecs/bech32" containing classes related to Bech32 encoding/decoding
- created "codecs/rlp" containing classes related to RLP (Recursive Length Prefix) encoding/decoding
- updated hex_codec.dart with missing functionalities imported from "cryptography_utils" package
- created big_int_utils.dart with utility methods for handling BigInt values. This file was copied from the "cryptography_utils" package and is used in: base58_codec.dart and rlp_bytes.dart
- renamed imported codec files to include the "codec" suffix (base58_encoder.dart -> base58_codec.dart, hex_encoder.dart -> hex_codec.dart, rlp_coder.dart -> rlp_codec.dart). These classes contained both encoding and decoding methods, so it was decided to distinguish them. Now “Encoder” stores only methods related to encoding, “Decoder” - methods related to decoding and “Codec” containing both functionalities.