### PR TITLE
Feature: Protobuf encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Flutter Version Management
 .fvm/flutter_sdk
+.fvm/versions
+.fvm/version
+.fvm/release
+.fvmrc
 
 # Miscellaneous
 *.class

--- a/lib/codec_utils.dart
+++ b/lib/codec_utils.dart
@@ -31,6 +31,13 @@ export 'src/codecs/cbor/export.dart';
 ///  ```
 export 'src/codecs/hex/hex_codec.dart';
 
+/// Classes for encoding cosmos messages using minimal protobuf encoding.
+/// Usage:
+///  ```
+///  List<int> ProtobufEncoder.encode(1, protobufMessage);
+///  ```
+export 'src/codecs/protobuf/export.dart';
+
 ///  Provides static utility methods for encoding and decoding data using the Recursive Length Prefix (RLP) encoding scheme.
 ///  Usage:
 ///   ```

--- a/lib/src/codecs/protobuf/a_protobuf_field.dart
+++ b/lib/src/codecs/protobuf/a_protobuf_field.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+
+/// An abstract base class representing a Protobuf field.
+/// It provides a common interface for encoding fields and checking for default values.
+abstract class AProtobufField with EquatableMixin {
+  /// Constructs a [AProtobufField] object.
+  const AProtobufField();
+
+  /// Encodes the Protobuf field using the provided field number.
+  List<int> encode(int fieldNumber);
+
+  /// Checks if the field has a default value.
+  /// By default, returns `false` unless overridden.
+  bool hasDefaultValue() => false;
+}

--- a/lib/src/codecs/protobuf/a_protobuf_object.dart
+++ b/lib/src/codecs/protobuf/a_protobuf_object.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// An abstract base class representing a complex Protobuf object.
+/// This class extends [AProtobufField], allowing to nest objects within other objects.
+abstract class AProtobufObject extends AProtobufField {
+  /// Creates an [AProtobufObject] object.
+  const AProtobufObject();
+
+  /// Encodes the object into a Protobuf byte field using the given field number.
+  /// The object is first converted into bytes and then encoded.
+  @override
+  List<int> encode(int fieldNumber) {
+    return ProtobufBytes(toProtoBytes()).encode(fieldNumber);
+  }
+
+  /// Converts the object into a byte array in Protobuf format.
+  Uint8List toProtoBytes();
+
+  /// Converts the object into a JSON-compatible map format.
+  Map<String, dynamic> toProtoJson();
+}

--- a/lib/src/codecs/protobuf/export.dart
+++ b/lib/src/codecs/protobuf/export.dart
@@ -1,0 +1,13 @@
+export 'a_protobuf_field.dart';
+export 'a_protobuf_object.dart';
+export 'fields/protobuf_any.dart';
+export 'fields/protobuf_bool.dart';
+export 'fields/protobuf_bytes.dart';
+export 'fields/protobuf_enum.dart';
+export 'fields/protobuf_int32.dart';
+export 'fields/protobuf_int64.dart';
+export 'fields/protobuf_list.dart';
+export 'fields/protobuf_map.dart';
+export 'fields/protobuf_string.dart';
+export 'protobuf_encoder.dart';
+export 'protobuf_wire_type.dart';

--- a/lib/src/codecs/protobuf/fields/protobuf_any.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_any.dart
@@ -1,0 +1,72 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Represents a Protobuf Any type, which can contain arbitrary Protobuf messages identified by their type URL.
+/// https://protobuf.dev/programming-guides/proto3/#any
+class ProtobufAny extends AProtobufObject {
+  /// A URL that uniquely identifies the type of the contained Protobuf message
+  final String typeUrl;
+
+  /// Constructs a [ProtobufAny] object with the specified type URL.
+  const ProtobufAny({
+    required this.typeUrl,
+  });
+
+  /// Encodes the [ProtobufAny] message by encoding both the type URL
+  /// and the Protobuf message bytes using the given field number.
+  @override
+  List<int> encode(int fieldNumber) {
+    return ProtobufBytes(ProtobufEncoder.encode(
+      <int, AProtobufField>{
+        1: ProtobufString(typeUrl),
+        2: ProtobufBytes(toProtoBytes()),
+      },
+    )).encode(fieldNumber);
+  }
+
+  /// Converts the contained message to a byte array in Protobuf format.
+  @override
+  Uint8List toProtoBytes() => Uint8List(0);
+
+  /// Converts the message to a JSON-compatible format, with the type URL included.
+  @override
+  Map<String, dynamic> toProtoJson() => <String, dynamic>{'@type': typeUrl};
+
+  @override
+  List<Object?> get props => <Object>[typeUrl];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_bool.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_bool.dart
@@ -1,0 +1,50 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Represents a boolean value encoded as an `int` in Protobuf format.
+/// This class extends [ProtobufInt32], storing a boolean value as 0 or 1.
+class ProtobufBool extends ProtobufInt32 {
+  /// The encoding type for this class, set to varint.
+  static const ProtobufWireType wireType = ProtobufWireType.varint;
+
+  /// Constructs a [ProtobufBool] object, converting a boolean value to an integer value of 0 or 1.
+  // ignore: avoid_positional_boolean_parameters
+  const ProtobufBool(bool value) : super(value ? 1 : 0);
+
+  /// Determines whether the value has the default value (false).
+  @override
+  bool hasDefaultValue() => value == 0;
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_bytes.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_bytes.dart
@@ -1,0 +1,67 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:codec_utils/src/codecs/protobuf/protobuf_utils.dart';
+
+/// Represents a byte array encoded in Protobuf format.
+/// This class extends [AProtobufField], storing a list of integers (bytes).
+class ProtobufBytes extends AProtobufField {
+  /// The wire type for this class, set to len for length-delimited fields.
+  static const ProtobufWireType wireType = ProtobufWireType.len;
+
+  /// A list of integers representing the byte data.
+  final List<int> value;
+
+  /// Constructs a [ProtobufBytes] object with the given byte list.
+  const ProtobufBytes(this.value);
+
+  /// Encodes the field number and byte list into a Protobuf format.
+  @override
+  List<int> encode(int fieldNumber) {
+    List<int> result = <int>[
+      ...ProtobufUtils.encodeLength(fieldNumber, value.length),
+      ...value,
+    ];
+
+    return result;
+  }
+
+  /// Checks if the byte list is empty, indicating the default value.
+  @override
+  bool hasDefaultValue() => value.isEmpty;
+
+  @override
+  List<Object?> get props => <Object?>[value];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_enum.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_enum.dart
@@ -1,0 +1,52 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Abstract class representing a Protobuf enumeration with a value and a name.
+///
+/// https://protobuf.dev/programming-guides/enum/
+abstract class ProtobufEnum extends ProtobufInt32 {
+  /// The encoding type for this class, set to varint.
+  static const ProtobufWireType wireType = ProtobufWireType.varint;
+
+  /// The name of the enumeration.
+  final String name;
+
+  /// Constructs a [ProtobufEnum] with the provided value and name.
+  const ProtobufEnum(int value, this.name) : super(value);
+
+  @override
+  List<Object?> get props => <Object?>[value, name];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_int32.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_int32.dart
@@ -1,0 +1,75 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:codec_utils/src/codecs/protobuf/protobuf_utils.dart';
+
+/// Represents a 32-bit integer value in Protobuf format.
+/// This class extends [AProtobufField] and is responsible for encoding 32-bit integers using Protobuf varint encoding scheme.
+class ProtobufInt32 extends AProtobufField {
+  /// The encoding type for this class, set to varint.
+  static const ProtobufWireType wireType = ProtobufWireType.varint;
+
+  /// The integer value stored by this Protobuf field.
+  final int value;
+
+  /// Constructs a [ProtobufInt32] object with the given integer value.
+  const ProtobufInt32(this.value);
+
+  /// Encodes the integer value along with its field number using varint encoding.
+  /// Handles both positive and negative values, applying ZigZag encoding for negative numbers.
+  @override
+  List<int> encode(int fieldNumber) {
+    List<int> result = <int>[];
+
+    int tag = ProtobufUtils.createTag(fieldNumber, wireType);
+    result.addAll(ProtobufUtils.encodeVarint32(tag));
+
+    if (value.isNegative) {
+      BigInt zigzag = (BigInt.from(value) & ProtobufUtils.maxInt64) | ProtobufUtils.minInt64;
+      result.addAll(ProtobufUtils.encodeVarint64(zigzag));
+      return result;
+    }
+    result.addAll(ProtobufUtils.encodeVarint32(value));
+
+    return result;
+  }
+
+  /// Determines whether the value has the default value (0).
+  @override
+  bool hasDefaultValue() => value == 0;
+
+  @override
+  List<Object?> get props => <Object?>[value];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_int64.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_int64.dart
@@ -1,0 +1,74 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:codec_utils/src/codecs/protobuf/protobuf_utils.dart';
+
+/// Represents a 64-bit integer value in Protobuf format.
+/// This class extends [AProtobufField] and is responsible for encoding 64-bit integers using Protobuf varint encoding scheme.
+class ProtobufInt64 extends AProtobufField {
+  /// The encoding type for this class, set to varint.
+  static const ProtobufWireType wireType = ProtobufWireType.varint;
+
+  /// The 64-bit integer value stored by this Protobuf field.
+  final BigInt value;
+
+  /// Constructs a [ProtobufInt64] object with the given BigInt value.
+  const ProtobufInt64(this.value);
+
+  /// Encodes the 64-bit integer value along with its field number using varint encoding.
+  /// Applies ZigZag encoding for negative numbers to optimize their representation.
+  @override
+  List<int> encode(int fieldNumber) {
+    List<int> result = <int>[];
+
+    int tag = ProtobufUtils.createTag(fieldNumber, wireType);
+    result.addAll(ProtobufUtils.encodeVarint32(tag));
+
+    BigInt maybeZigZag = value;
+    if (value.isNegative) {
+      maybeZigZag = (value & ProtobufUtils.maxInt64) | ProtobufUtils.minInt64;
+    }
+
+    result.addAll(ProtobufUtils.encodeVarint64(maybeZigZag));
+    return result;
+  }
+
+  /// Determines whether the value has the default value (0).
+  @override
+  bool hasDefaultValue() => value == BigInt.zero;
+
+  @override
+  List<Object?> get props => <Object?>[value];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_list.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_list.dart
@@ -1,0 +1,62 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Represents a list of Protobuf fields.
+/// This class extends [AProtobufField] and is responsible for encoding a list of Protobuf fields.
+class ProtobufList extends AProtobufField {
+  /// A list of [AProtobufField] objects to be encoded.
+  final List<AProtobufField> value;
+
+  /// Constructs a [ProtobufList] object with the given list of Protobuf fields.
+  const ProtobufList(this.value);
+
+  /// Encodes each field in the list using the provided field number.
+  @override
+  List<int> encode(int fieldNumber) {
+    List<int> result = <int>[];
+    for (AProtobufField item in value) {
+      result.addAll(item.encode(fieldNumber));
+    }
+    return result;
+  }
+
+  /// Checks if the list is empty, indicating the default value.
+  @override
+  bool hasDefaultValue() => value.isEmpty;
+
+  @override
+  List<Object?> get props => <Object>[value];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_map.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_map.dart
@@ -1,0 +1,70 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:codec_utils/src/codecs/protobuf/protobuf_utils.dart';
+
+/// Represents a map of key-value pairs in Protobuf format.
+/// This class extends [AProtobufField] and is responsible for encoding a map of Protobuf fields.
+class ProtobufMap extends AProtobufField {
+  /// A map where both keys and values are [AProtobufField] objects.
+  final Map<AProtobufField, AProtobufField> value;
+
+  /// Constructs a [ProtobufMap] object with the given map of Protobuf fields.
+  const ProtobufMap(this.value);
+
+  /// Encodes each key-value pair in the map using the provided field number.
+  /// Both the key and value are encoded, with the length of the encoded data being calculated.
+  @override
+  List<int> encode(int fieldNumber) {
+    List<int> result = <int>[];
+    for (MapEntry<AProtobufField, AProtobufField> entry in value.entries) {
+      List<int> encodedKey = entry.key.encode(fieldNumber);
+      List<int> encodedValue = entry.value.encode(fieldNumber);
+
+      result
+        ..addAll(ProtobufUtils.encodeLength(fieldNumber, encodedKey.length + encodedValue.length))
+        ..addAll(encodedKey)
+        ..addAll(encodedValue);
+    }
+    return result;
+  }
+
+  /// Checks if the map is empty, indicating the default value.
+  @override
+  bool hasDefaultValue() => value.isEmpty;
+
+  @override
+  List<Object?> get props => <Object>[value];
+}

--- a/lib/src/codecs/protobuf/fields/protobuf_string.dart
+++ b/lib/src/codecs/protobuf/fields/protobuf_string.dart
@@ -1,0 +1,56 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:convert';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// Represents a string value in Protobuf format.
+/// This class extends [ProtobufBytes] and is responsible for encoding strings as UTF-8 encoded bytes in Protobuf format.
+class ProtobufString extends ProtobufBytes {
+  /// The wire type for this class, set to `len` for length-delimited fields.
+  static const ProtobufWireType wireType = ProtobufWireType.len;
+
+  /// Factory constructor that creates a [ProtobufString] by encoding the given string as UTF-8 bytes.
+  factory ProtobufString(String value) {
+    return ProtobufString._(utf8.encode(value));
+  }
+
+  /// Private constructor used by factory constructor to build [ProtobufString]
+  const ProtobufString._(super.bytes);
+
+  /// Checks if the current string value is the default (empty).
+  @override
+  bool hasDefaultValue() => value.isEmpty;
+}

--- a/lib/src/codecs/protobuf/protobuf_encoder.dart
+++ b/lib/src/codecs/protobuf/protobuf_encoder.dart
@@ -1,0 +1,63 @@
+// Class was shaped by the influence of several key sources including:
+// "cosmos_sdk" - Copyright 2023 MRTNETWORK
+// https://github.com/mrtnetwork/cosmos_sdk
+//
+// BSD 3-Clause License
+//
+// Copyright 2023 MRTNETWORK
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+
+/// A class for encoding Protobuf fields into a byte array.
+/// It processes a map of Protobuf field entries and encodes each field into a list of bytes.
+class ProtobufEncoder {
+  /// Encodes a map of Protobuf field entries into a Protobuf byte array.
+  /// Each field is encoded based on its field number, skipping fields that are null or have a default value
+  static Uint8List encode(Map<int, AProtobufField?> protobufEntries) {
+    List<int> result = <int>[];
+    for (MapEntry<int, AProtobufField?> protobufEntry in protobufEntries.entries) {
+      int fieldNumber = protobufEntry.key;
+      AProtobufField? protobufField = protobufEntry.value;
+
+      if (protobufField == null) {
+        continue;
+      }
+
+      if (protobufField.hasDefaultValue()) {
+        continue;
+      }
+
+      List<int> value = protobufField.encode(fieldNumber);
+      result.addAll(value);
+    }
+    return Uint8List.fromList(result);
+  }
+}

--- a/lib/src/codecs/protobuf/protobuf_utils.dart
+++ b/lib/src/codecs/protobuf/protobuf_utils.dart
@@ -1,0 +1,50 @@
+import 'package:codec_utils/codec_utils.dart';
+
+/// A utility class for various Protobuf-related encoding operations.
+/// It provides methods for encoding integers and managing Protobuf field tags.
+class ProtobufUtils {
+  /// The maximum value for a 64-bit signed integer in Protobuf format.
+  static final BigInt maxInt64 = BigInt.parse('7FFFFFFFFFFFFFFF', radix: 16);
+
+  /// The minimum value for a 64-bit signed integer in Protobuf format.
+  static final BigInt minInt64 = BigInt.parse('8000000000000000', radix: 16);
+
+  /// Encodes the length of a field along with its field number using varint encoding.
+  /// This is used for length-delimited fields.
+  static List<int> encodeLength(int fieldNumber, int value) {
+    int tag = ProtobufUtils.createTag(fieldNumber, ProtobufWireType.len);
+    return <int>[
+      ...ProtobufUtils.encodeVarint32(tag),
+      ...ProtobufUtils.encodeVarint32(value),
+    ];
+  }
+
+  /// Creates a Protobuf field tag by combining the field number and wire type.
+  static int createTag(int fieldNumber, ProtobufWireType protobufWireType) {
+    return (fieldNumber << 3) | protobufWireType.id;
+  }
+
+  /// Encodes a 32-bit integer using varint encoding.
+  static List<int> encodeVarint32(int inputValue) {
+    int value = inputValue;
+    List<int> result = <int>[];
+    while (value > 0x7F) {
+      result.add((value & 0x7F) | 0x80);
+      value >>= 7;
+    }
+    result.add(value);
+    return result;
+  }
+
+  /// Encodes a 64-bit integer using varint encoding.
+  static List<int> encodeVarint64(BigInt inputValue) {
+    BigInt value = inputValue;
+    List<int> result = <int>[];
+    while (value > BigInt.from(0x7F)) {
+      result.add((value & BigInt.from(0x7F) | BigInt.from(0x80)).toInt());
+      value >>= 7;
+    }
+    result.add(value.toInt());
+    return result;
+  }
+}

--- a/lib/src/codecs/protobuf/protobuf_wire_type.dart
+++ b/lib/src/codecs/protobuf/protobuf_wire_type.dart
@@ -1,0 +1,23 @@
+enum ProtobufWireType {
+  /// Used for int32, int64, uint32, uint64, sint32, sint64, bool, enum
+  varint(0),
+
+  /// Used for fixed64, sfixed64, double
+  i64(1),
+
+  /// Used for string, bytes, embedded messages, packed repeated fields
+  len(2),
+
+  /// Used for group start (deprecated)
+  sgroup(3),
+
+  /// Used for group end (deprecated)
+  egroup(4),
+
+  /// Used for fixed32, fixed32, float
+  i32(5);
+
+  final int id;
+
+  const ProtobufWireType(this.id);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: codec_utils
 description: "Dart package containing utility methods for data encoding and decoding"
-version: 0.0.3
+version: 0.0.4
 publish_to: none
 
 environment:

--- a/test/unit/codecs/protobuf/fields/protobuf_any_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_any_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufAny.encode()', () {
+    test('Should [return bytes] representing Any encoded with protobuf', () {
+      // Arrange
+      ProtobufAny actualProtobufAny = TestProtobufAny(
+        typeUrl: '/test.gov.TestProtobufAny',
+        data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+      );
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufAny.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = base64Decode('CicKGS90ZXN0Lmdvdi5UZXN0UHJvdG9idWZBbnkSCgECAwQFBgcICQA=');
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufAny.toProtoBytes()', () {
+    test('Should [return EMPTY Uint8List]', () {
+      // Arrange
+      ProtobufAny actualProtobufAny = TestProtobufAny(
+        typeUrl: '/test.gov.TestProtobufAny',
+        data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+      );
+
+      // Act
+      Uint8List actualUint8List = actualProtobufAny.toProtoBytes();
+
+      // Assert
+      Uint8List expectedUint8List = Uint8List.fromList(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+
+      expect(actualUint8List, expectedUint8List);
+    });
+  });
+
+  group('Tests of ProtobufAny.toProtoJson()', () {
+    test('Should [return Map<String, dynamic>] with type URL', () {
+      // Arrange
+      ProtobufAny actualProtobufAny = TestProtobufAny(
+        typeUrl: '/test.gov.TestProtobufAny',
+        data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+      );
+
+      // Act
+      Map<String, dynamic> actualMap = actualProtobufAny.toProtoJson();
+
+      // Assert
+      expect(actualMap, <String, dynamic>{
+        '@type': '/test.gov.TestProtobufAny',
+        'data': 'AQIDBAUGBwgJAA==',
+      });
+    });
+  });
+}
+
+class TestProtobufAny extends ProtobufAny {
+  final List<int> data;
+
+  TestProtobufAny({
+    required super.typeUrl,
+    required this.data,
+  });
+
+  @override
+  Uint8List toProtoBytes() {
+    return Uint8List.fromList(data);
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'data': base64Encode(data),
+    };
+  }
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_bool_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_bool_test.dart
@@ -1,0 +1,56 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufBool.encode()', () {
+    test('Should [return bytes] representing bool (TRUE) encoded with protobuf', () {
+      // Arrange
+      ProtobufBool actualProtobufBool = const ProtobufBool(true);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufBool.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing bool (FALSE) encoded with protobuf', () {
+      // Arrange
+      ProtobufBool actualProtobufBool = const ProtobufBool(false);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufBool.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 0];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufBool.hasDefaultValue()', () {
+    test('Should [return TRUE] when [bool == FALSE]', () {
+      // Arrange
+      ProtobufBool actualProtobufBool = const ProtobufBool(false);
+
+      // Act
+      bool actualResult = actualProtobufBool.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [bool == TRUE]', () {
+      // Arrange
+      ProtobufBool actualProtobufBool = const ProtobufBool(true);
+
+      // Act
+      bool actualResult = actualProtobufBool.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_bytes_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_bytes_test.dart
@@ -1,0 +1,43 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufBytes.encode()', () {
+    test('Should [return bytes] representing bytes encoded with protobuf', () {
+      // Arrange
+      ProtobufBytes actualProtobufBytes = const ProtobufBytes(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufBytes.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[10, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufBytes.hasDefaultValue()', () {
+    test('Should [return TRUE] when [bytes EMPTY]', () {
+      // Arrange
+      ProtobufBytes actualProtobufBytes = const ProtobufBytes(<int>[]);
+
+      // Act
+      bool actualResult = actualProtobufBytes.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return TRUE] when [bytes NOT EMPTY]', () {
+      // Arrange
+      ProtobufBytes actualProtobufBytes = const ProtobufBytes(<int>[1, 2, 3]);
+
+      // Act
+      bool actualResult = actualProtobufBytes.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_enum_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_enum_test.dart
@@ -1,0 +1,23 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufEnum.encode()', () {
+    test('Should [return bytes] representing Enum encoded with protobuf', () {
+      // Arrange
+      ProtobufEnum actualProtobufEnum = TestProtobufEnum(1, 'test');
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufEnum.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+}
+
+class TestProtobufEnum extends ProtobufEnum {
+  TestProtobufEnum(super.value, super.name);
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_int32_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_int32_test.dart
@@ -1,0 +1,69 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufInt32.encode()', () {
+    test('Should [return bytes] representing Int32 encoded with protobuf (Int32 == 0)', () {
+      // Arrange
+      ProtobufInt32 actualProtobufInt32 = const ProtobufInt32(0);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt32.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 0];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int32 encoded with protobuf (Int32 < 0)', () {
+      // Arrange
+      ProtobufInt32 actualProtobufInt32 = const ProtobufInt32(-1234567890);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt32.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 174, 250, 167, 179, 251, 255, 255, 255, 255, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int32 encoded with protobuf (Int32 > 0)', () {
+      // Arrange
+      ProtobufInt32 actualProtobufInt32 = const ProtobufInt32(1234567890);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt32.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 210, 133, 216, 204, 4];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufInt32.hasDefaultValue()', () {
+    test('Should [return TRUE] when [int32 == 0]', () {
+      // Arrange
+      ProtobufInt32 actualProtobufInt32 = const ProtobufInt32(0);
+
+      // Act
+      bool actualResult = actualProtobufInt32.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [int32 != 0]', () {
+      // Arrange
+      ProtobufInt32 actualProtobufInt32 = const ProtobufInt32(1);
+
+      // Act
+      bool actualResult = actualProtobufInt32.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_int64_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_int64_test.dart
@@ -1,0 +1,95 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufInt64.encode()', () {
+    test('Should [return bytes] representing Int64 encoded with protobuf (Int64 == 0)', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.from(0));
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt64.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 0];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int64 encoded with protobuf (Int64 < Int32 < 0)', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.parse('-12345678901234567890'));
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt64.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 174, 234, 131, 167, 177, 206, 213, 213, 212, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int64 encoded with protobuf (Int32 < Int64 < 0)', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.from(-1234567890));
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt64.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 174, 250, 167, 179, 251, 255, 255, 255, 255, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int64 encoded with protobuf (0 < Int64 < Int32)', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.from(1234567890));
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt64.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 210, 133, 216, 204, 4];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing Int64 encoded with protobuf (0 < Int32 > Int64)', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.parse('12345678901234567890'));
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufInt64.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[8, 210, 149, 252, 216, 206, 177, 170, 170, 171, 1];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufInt64.hasDefaultValue()', () {
+    test('Should [return TRUE] when [int64 == 0]', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.zero);
+
+      // Act
+      bool actualResult = actualProtobufInt64.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [int64 != 0]', () {
+      // Arrange
+      ProtobufInt64 actualProtobufInt64 = ProtobufInt64(BigInt.from(1));
+
+      // Act
+      bool actualResult = actualProtobufInt64.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_list_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_list_test.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufList.encode()', () {
+    test('Should [return bytes] representing List encoded with protobuf', () {
+      // Arrange
+      ProtobufList actualProtobufList = ProtobufList(<AProtobufField>[
+        const TestProtobufAny(typeUrl: '/test.gov.TestProtobufAny', data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        const ProtobufBool(false),
+        const ProtobufBool(true),
+        const ProtobufBytes(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        const TestProtobufEnum(1, 'test'),
+        const ProtobufInt32(-256),
+        const ProtobufInt32(256),
+        ProtobufInt64(BigInt.parse('123456789123456789')),
+        ProtobufInt64(BigInt.parse('-123456789123456789')),
+        ProtobufList(<AProtobufField>[
+          const TestProtobufAny(typeUrl: '/test.gov.TestProtobufAny', data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+          const ProtobufBool(false),
+          const ProtobufBool(true),
+          const ProtobufBytes(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+          const TestProtobufEnum(1, 'test'),
+          const ProtobufInt32(-256),
+          const ProtobufInt32(256),
+          ProtobufInt64(BigInt.parse('123456789123456789')),
+          ProtobufInt64(BigInt.parse('-123456789123456789')),
+          ProtobufString('Hello World!'),
+        ]),
+        ProtobufMap(<AProtobufField, AProtobufField>{
+          const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]): const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]),
+          const ProtobufBool(false): const ProtobufBool(false),
+          const ProtobufBool(true): const ProtobufBool(true),
+          const ProtobufBytes(<int>[1]): const ProtobufBytes(<int>[1]),
+          const TestProtobufEnum(1, 'test'): const TestProtobufEnum(1, 'test'),
+          const ProtobufInt32(-256): const ProtobufInt32(-256),
+          const ProtobufInt32(256): const ProtobufInt32(256),
+          ProtobufInt64(BigInt.parse('123456789123456789')): ProtobufInt64(BigInt.parse('123456789123456789')),
+          ProtobufInt64(BigInt.parse('-123456789123456789')): ProtobufInt64(BigInt.parse('-123456789123456789')),
+          ProtobufString('Hello World!'): ProtobufString('Hello World!'),
+        }),
+        ProtobufString('Hello World!'),
+      ]);
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufList.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = base64Decode(
+        'CicKGS90ZXN0Lmdvdi5UZXN0UHJvdG9idWZBbnkSCgECAwQFBgcICQAIAAgBCgoBAgMEBQYHCAkACAEIgP7/////////AQiAAgiVvsHmuumm2wEI68G+mcWW2aT+AQonChkvdGVzdC5nb3YuVGVzdFByb3RvYnVmQW55EgoBAgMEBQYHCAkACAAIAQoKAQIDBAUGBwgJAAgBCID+/////////wEIgAIIlb7B5rrpptsBCOvBvpnFltmk/gEKDEhlbGxvIFdvcmxkIQo4ChoKFS90ZXN0LlRlc3RQcm90b2J1ZkFueRIBAQoaChUvdGVzdC5UZXN0UHJvdG9idWZBbnkSAQEKBAgACAAKBAgBCAEKBgoBAQoBAQoECAEIAQoWCID+/////////wEIgP7/////////AQoGCIACCIACChQIlb7B5rrpptsBCJW+wea66abbAQoWCOvBvpnFltmk/gEI68G+mcWW2aT+AQocCgxIZWxsbyBXb3JsZCEKDEhlbGxvIFdvcmxkIQoMSGVsbG8gV29ybGQh',
+      );
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufList.hasDefaultValue()', () {
+    test('Should [return TRUE] when [list EMPTY]', () {
+      // Arrange
+      ProtobufList actualProtobufList = const ProtobufList(<AProtobufField>[]);
+
+      // Act
+      bool actualResult = actualProtobufList.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [list NOT EMPTY]', () {
+      // Arrange
+      ProtobufList actualProtobufList = const ProtobufList(<AProtobufField>[
+        ProtobufBool(true),
+      ]);
+
+      // Act
+      bool actualResult = actualProtobufList.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}
+
+class TestProtobufAny extends ProtobufAny {
+  final List<int> data;
+
+  const TestProtobufAny({
+    required super.typeUrl,
+    required this.data,
+  });
+
+  @override
+  Uint8List toProtoBytes() {
+    return Uint8List.fromList(data);
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'data': base64Encode(data),
+    };
+  }
+}
+
+class TestProtobufEnum extends ProtobufEnum {
+  const TestProtobufEnum(super.value, super.name);
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_map_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_map_test.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufMap.encode()', () {
+    test('Should [return bytes] representing Map encoded with protobuf', () {
+      // Arrange
+      ProtobufMap actualProtobufMap = ProtobufMap(<AProtobufField, AProtobufField>{
+        const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]): const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]),
+        const ProtobufBool(false): const ProtobufBool(false),
+        const ProtobufBool(true): const ProtobufBool(true),
+        const ProtobufBytes(<int>[1]): const ProtobufBytes(<int>[1]),
+        const TestProtobufEnum(1, 'test'): const TestProtobufEnum(1, 'test'),
+        const ProtobufInt32(-256): const ProtobufInt32(-256),
+        const ProtobufInt32(256): const ProtobufInt32(256),
+        ProtobufInt64(BigInt.parse('123456789123456789')): ProtobufInt64(BigInt.parse('123456789123456789')),
+        ProtobufInt64(BigInt.parse('-123456789123456789')): ProtobufInt64(BigInt.parse('-123456789123456789')),
+        ProtobufString('Hello World!'): ProtobufString('Hello World!'),
+      });
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufMap.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = base64Decode(
+        'CjgKGgoVL3Rlc3QuVGVzdFByb3RvYnVmQW55EgEBChoKFS90ZXN0LlRlc3RQcm90b2J1ZkFueRIBAQoECAAIAAoECAEIAQoGCgEBCgEBCgQIAQgBChYIgP7/////////AQiA/v////////8BCgYIgAIIgAIKFAiVvsHmuumm2wEIlb7B5rrpptsBChYI68G+mcWW2aT+AQjrwb6ZxZbZpP4BChwKDEhlbGxvIFdvcmxkIQoMSGVsbG8gV29ybGQh',
+      );
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufMap.hasDefaultValue()', () {
+    test('Should [return TRUE] when [map EMPTY]', () {
+      // Arrange
+      ProtobufMap actualProtobufMap = const ProtobufMap(<AProtobufField, AProtobufField>{});
+
+      // Act
+      bool actualResult = actualProtobufMap.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [map NOT EMPTY]', () {
+      // Arrange
+      ProtobufMap actualProtobufMap = ProtobufMap(<AProtobufField, AProtobufField>{
+        const ProtobufInt32(1): ProtobufString('Hello World!'),
+      });
+
+      // Act
+      bool actualResult = actualProtobufMap.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}
+
+class TestProtobufAny extends ProtobufAny {
+  final List<int> data;
+
+  const TestProtobufAny({
+    required super.typeUrl,
+    required this.data,
+  });
+
+  @override
+  Uint8List toProtoBytes() {
+    return Uint8List.fromList(data);
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'data': base64Encode(data),
+    };
+  }
+}
+
+class TestProtobufEnum extends ProtobufEnum {
+  const TestProtobufEnum(super.value, super.name);
+}

--- a/test/unit/codecs/protobuf/fields/protobuf_string_test.dart
+++ b/test/unit/codecs/protobuf/fields/protobuf_string_test.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufString.encode()', () {
+    test('Should [return bytes] representing String encoded with protobuf (String EMPTY)', () {
+      // Arrange
+      ProtobufString actualProtobufString = ProtobufString('');
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufString.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[10, 0];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return bytes] representing String encoded with protobuf (String NOT EMPTY)', () {
+      // Arrange
+      ProtobufString actualProtobufString = ProtobufString('/test.gov.TestProtobufAny');
+
+      // Act
+      List<int> actualProtobufResult = actualProtobufString.encode(1);
+
+      // Assert
+      List<int> expectedProtobufResult = base64Decode('ChkvdGVzdC5nb3YuVGVzdFByb3RvYnVmQW55');
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+
+  group('Tests of ProtobufString.hasDefaultValue()', () {
+    test('Should [return TRUE] when [string EMPTY]', () {
+      // Arrange
+      ProtobufString actualProtobufString = ProtobufString('');
+
+      // Act
+      bool actualResult = actualProtobufString.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, true);
+    });
+
+    test('Should [return FALSE] when [string NOT EMPTY]', () {
+      // Arrange
+      ProtobufString actualProtobufString = ProtobufString('Hello World!');
+
+      // Act
+      bool actualResult = actualProtobufString.hasDefaultValue();
+
+      // Assert
+      expect(actualResult, false);
+    });
+  });
+}

--- a/test/unit/codecs/protobuf/protobuf_encoder_test.dart
+++ b/test/unit/codecs/protobuf/protobuf_encoder_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:codec_utils/codec_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufEncoder.encode()', () {
+    test('Should [return bytes] representing encoded Protobuf entries (entries have NOT DEFAULT values)', () {
+      // Arrange
+      Map<int, AProtobufField> actualProtobufEntries = <int, AProtobufField>{
+        0: const TestProtobufAny(typeUrl: '/test.gov.TestProtobufAny', data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        2: const ProtobufBool(true),
+        3: const ProtobufBytes(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        4: const TestProtobufEnum(1, 'test'),
+        5: const ProtobufInt32(-256),
+        6: const ProtobufInt32(256),
+        7: ProtobufInt64(BigInt.parse('123456789123456789')),
+        8: ProtobufInt64(BigInt.parse('-123456789123456789')),
+        9: ProtobufList(<AProtobufField>[
+          const TestProtobufAny(typeUrl: '/test.gov.TestProtobufAny', data: <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+          const ProtobufBool(true),
+          const ProtobufBytes(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+          const TestProtobufEnum(1, 'test'),
+          const ProtobufInt32(-256),
+          const ProtobufInt32(256),
+          ProtobufInt64(BigInt.parse('123456789123456789')),
+          ProtobufInt64(BigInt.parse('-123456789123456789')),
+          ProtobufString('Hello World!'),
+        ]),
+        10: ProtobufMap(<AProtobufField, AProtobufField>{
+          const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]): const TestProtobufAny(typeUrl: '/test.TestProtobufAny', data: <int>[1]),
+          const ProtobufBool(true): const ProtobufBool(true),
+          const ProtobufBytes(<int>[1]): const ProtobufBytes(<int>[1]),
+          const TestProtobufEnum(1, 'test'): const TestProtobufEnum(1, 'test'),
+          const ProtobufInt32(-256): const ProtobufInt32(-256),
+          const ProtobufInt32(256): const ProtobufInt32(256),
+          ProtobufInt64(BigInt.parse('123456789123456789')): ProtobufInt64(BigInt.parse('123456789123456789')),
+          ProtobufInt64(BigInt.parse('-123456789123456789')): ProtobufInt64(BigInt.parse('-123456789123456789')),
+          ProtobufString('Hello World!'): ProtobufString('Hello World!'),
+        }),
+        11: ProtobufString('Hello World!'),
+      };
+
+      // Act
+      List<int> actualProtobufResult = ProtobufEncoder.encode(actualProtobufEntries);
+
+      // Assert
+      List<int> expectedProtobufResult = base64Decode(
+        'AicKGS90ZXN0Lmdvdi5UZXN0UHJvdG9idWZBbnkSCgECAwQFBgcICQAQARoKAQIDBAUGBwgJACABKID+/////////wEwgAI4lb7B5rrpptsBQOvBvpnFltmk/gFKJwoZL3Rlc3QuZ292LlRlc3RQcm90b2J1ZkFueRIKAQIDBAUGBwgJAEgBSgoBAgMEBQYHCAkASAFIgP7/////////AUiAAkiVvsHmuumm2wFI68G+mcWW2aT+AUoMSGVsbG8gV29ybGQhUjhSGgoVL3Rlc3QuVGVzdFByb3RvYnVmQW55EgEBUhoKFS90ZXN0LlRlc3RQcm90b2J1ZkFueRIBAVIEUAFQAVIGUgEBUgEBUgRQAVABUhZQgP7/////////AVCA/v////////8BUgZQgAJQgAJSFFCVvsHmuumm2wFQlb7B5rrpptsBUhZQ68G+mcWW2aT+AVDrwb6ZxZbZpP4BUhxSDEhlbGxvIFdvcmxkIVIMSGVsbG8gV29ybGQhWgxIZWxsbyBXb3JsZCE=',
+      );
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return empty bytes] when (entries have DEFAULT values)', () {
+      // Arrange
+      Map<int, AProtobufField> actualProtobufEntries = <int, AProtobufField>{
+        0: const ProtobufBool(false),
+        1: const ProtobufBytes(<int>[]),
+        2: const ProtobufInt32(0),
+        3: ProtobufInt64(BigInt.zero),
+        4: const ProtobufList(<AProtobufField>[]),
+        5: const ProtobufMap(<AProtobufField, AProtobufField>{}),
+        6: ProtobufString(''),
+      };
+
+      // Act
+      List<int> actualProtobufResult = ProtobufEncoder.encode(actualProtobufEntries);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+
+    test('Should [return empty bytes] when (entries have NULL values)', () {
+      // Arrange
+      Map<int, AProtobufField?> actualProtobufEntries = <int, AProtobufField?>{
+        0: null,
+        1: null,
+        2: null,
+        3: null,
+      };
+
+      // Act
+      List<int> actualProtobufResult = ProtobufEncoder.encode(actualProtobufEntries);
+
+      // Assert
+      List<int> expectedProtobufResult = <int>[];
+
+      expect(actualProtobufResult, expectedProtobufResult);
+    });
+  });
+}
+
+class TestProtobufAny extends ProtobufAny {
+  final List<int> data;
+
+  const TestProtobufAny({
+    required super.typeUrl,
+    required this.data,
+  });
+
+  @override
+  Uint8List toProtoBytes() {
+    return Uint8List.fromList(data);
+  }
+
+  @override
+  Map<String, dynamic> toProtoJson() {
+    return <String, dynamic>{
+      '@type': typeUrl,
+      'data': base64Encode(data),
+    };
+  }
+}
+
+class TestProtobufEnum extends ProtobufEnum {
+  const TestProtobufEnum(super.value, super.name);
+}

--- a/test/unit/codecs/protobuf/protobuf_utils_test.dart
+++ b/test/unit/codecs/protobuf/protobuf_utils_test.dart
@@ -1,0 +1,263 @@
+import 'package:codec_utils/codec_utils.dart';
+import 'package:codec_utils/src/codecs/protobuf/protobuf_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Tests of ProtobufUtils.encodeLength()', () {
+    test('Should [return encoded length] for given length and field number (length < 128)', () {
+      // Act
+      List<int> actualEncodedLength = ProtobufUtils.encodeLength(1, 127);
+
+      // Assert
+      List<int> expectedEncodedLength = <int>[10, 127];
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
+
+    test('Should [return encoded length] for given length and field number (length > 128)', () {
+      // Act
+      List<int> actualEncodedLength = ProtobufUtils.encodeLength(1, 128);
+
+      // Assert
+      List<int> expectedEncodedLength = <int>[10, 128, 1];
+
+      expect(actualEncodedLength, expectedEncodedLength);
+    });
+  });
+
+  group('Tests of ProtobufUtils.createTag()', () {
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.varint)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.varint);
+
+      // Assert
+      int expectedTag = 8;
+
+      expect(actualTag, expectedTag);
+    });
+
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.i64)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.i64);
+
+      // Assert
+      int expectedTag = 9;
+
+      expect(actualTag, expectedTag);
+    });
+
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.len)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.len);
+
+      // Assert
+      int expectedTag = 10;
+
+      expect(actualTag, expectedTag);
+    });
+
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.sgroup)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.sgroup);
+
+      // Assert
+      int expectedTag = 11;
+
+      expect(actualTag, expectedTag);
+    });
+
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.egroup)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.egroup);
+
+      // Assert
+      int expectedTag = 12;
+
+      expect(actualTag, expectedTag);
+    });
+
+    test('Should [return tag] for given field number and wire type (ProtobufWireType.i32)', () {
+      // Act
+      int actualTag = ProtobufUtils.createTag(1, ProtobufWireType.i32);
+
+      // Assert
+      int expectedTag = 13;
+
+      expect(actualTag, expectedTag);
+    });
+  });
+
+  group('Tests of ProtobufUtils.encodeVarint32()', () {
+    test('Should [return encoded varint32] for given integer value (value 0-127)', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(127);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[127];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+
+    test('Should [return encoded varint32] for given integer value (value 128-16383)', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(128);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[128, 1];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+
+    test('Should [return encoded varint32] for given integer value (value 16384-2097151)', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(16384);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[128, 128, 1];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+
+    test('Should [return encoded varint32] for given integer value (value 2097152-268435455 )', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(2097152);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[128, 128, 128, 1];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+
+    test('Should [return encoded varint32] for given integer value (value 268435456-4294967295 )', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(268435456);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+
+    test('Should [return encoded varint32] for given integer value (max value)', () {
+      // Act
+      List<int> actualEncodedVarint32 = ProtobufUtils.encodeVarint32(4294967295);
+
+      // Assert
+      List<int> expectedEncodedVarint32 = <int>[255, 255, 255, 255, 15];
+
+      expect(actualEncodedVarint32, expectedEncodedVarint32);
+    });
+  });
+
+  group('Tests of ProtobufUtils.encodeVarint64()', () {
+    test('Should [return encoded varint64] for given BigInt value (value < 128)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('127'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[127];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 128-16383)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('128'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 16384-2097151)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('16384'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 2097152-268435455)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('2097152'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 268435456-34359738367)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('268435456'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 34359738368-4398046511103)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('34359738368'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 4398046511104-562949953421311)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('4398046511104'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 562949953421312-72057594037927935)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('562949953421312'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 72057594037927936-9223372036854775807)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('72057594037927936'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (value 9223372036854775808-18446744073709551615)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('9223372036854775808'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[128, 128, 128, 128, 128, 128, 128, 128, 128, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+
+    test('Should [return encoded varint64] for given BigInt value (max value)', () {
+      // Act
+      List<int> actualEncodedVarint64 = ProtobufUtils.encodeVarint64(BigInt.parse('18446744073709551615'));
+
+      // Assert
+      List<int> expectedEncodedVarint64 = <int>[255, 255, 255, 255, 255, 255, 255, 255, 255, 1];
+
+      expect(actualEncodedVarint64, expectedEncodedVarint64);
+    });
+  });
+}


### PR DESCRIPTION
This branch introduces Protocol Buffers (protobuf) encoding - a platform and language-neutral data serialization format developed by Google, designed for encoding structured data to facilitate communication between applications or for data storage. This branch supports encoding variables using the "varint" and "len" wire types. The remaining wire types, such as "i32," "i64," "sgroup," and "egroup," are not currently supported and will be implemented as project evolve.

List of changes:
- created protobuf_encoder.dart - class used for encoding messages using protobuf
- created a_protobuf_object.dart, an abstract class representing an object that contains its own .proto definition
- created a_protobuf_field.dart, an abstract class representing a generic type that may be used in .proto files
- created protobuf_bool.dart, protobuf_enum.dart, protobuf_int32.dart, protobuf_int64.dart representing VARINT wire types
- created protobuf_bytes.dart, protobuf_string.dart representing LEN wire types
- created protobuf_list.dart, protobuf_map.dart - a complex types, used to define lists and maps in protobuf object
- created protobuf_wire_type.dart containing an enum with all possible wire types in protobuf. Currently, only VARINT and LEN are implemented, as the remaining types are not commonly used and necessary at this moment.
- created protobuf_utils.dart containing utility methods for protobuf encoding